### PR TITLE
Fix the callback wrapper for the 'each' method

### DIFF
--- a/sqlite3-transactions.js
+++ b/sqlite3-transactions.js
@@ -1,4 +1,4 @@
-var sys = require('sys'),
+var util = require('util'),
     events = require('events'),
     _ = require("underscore");
 
@@ -83,7 +83,7 @@ function TransactionDatabase(database, exec) {
 		return newStatement;
 	};
 }
-sys.inherits(TransactionDatabase, events.EventEmitter);
+util.inherits(TransactionDatabase, events.EventEmitter);
 module.exports.TransactionDatabase = TransactionDatabase;
 
 
@@ -128,7 +128,7 @@ function wrapDbMethod(transactionDatabase, object, method) {
 			// hijack the callback to implement locking
 			var originalCallback;
 			var newCallback = function() {
-				if (transactionDatabase._lock<1) throw new Error("Locks are not ballanced. Sorry.");
+				if (transactionDatabase._lock<1) throw new Error("Locks are not balanced.");
 				transactionDatabase._lock--;
 				originalCallback.apply(this, arguments);
 			};

--- a/sqlite3-transactions.js
+++ b/sqlite3-transactions.js
@@ -111,8 +111,8 @@ function wrapDbMethod(transactionDatabase, object, method) {
 				if (e) transactionDatabase.db.emit("error", e);
 			};
 
-			// If needed add a dummy completion callback the 'each' method so the
-			// callback wrapper can decrement the lock value
+			// If needed add a dummy completion callback to the 'each' method so that
+			// the callback wrapper can decrement the lock value
 			if (method == 'each') {
 				if (arguments.length < 2 || !_.isFunction(args[args.length-1]) &&
 					!_.isFunction(args[args.length-2])) {

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ var sqlite3 = require("sqlite3"),
 	_ = require("underscore"),
 	slide = require("slide"),
 	fs = require("fs"),
-	sys = require('sys'),
+	util = require('util'),
     events = require('events');
 
 var TransactionDatabase = require("./sqlite3-transactions").TransactionDatabase;
@@ -16,7 +16,7 @@ function Runner (fn) {
 	this.fn = fn;
 	events.EventEmitter.call(this);
 }
-sys.inherits(Runner, events.EventEmitter);
+util.inherits(Runner, events.EventEmitter);
 
 Runner.prototype.start = function(interval) {
 	var self = this;


### PR DESCRIPTION
When calling `db.each` or `statement.each`, outside of a transaction, the callback wrapper attempts to decrement the lock value but if no completion callback is given, the wrapper will instead wrap the results callback causing the lock to decrement for each result row instead of at the end of the operation.

This PR adds dummy callbacks in the method wrapper to the `each` method so that the completion callback will always be called and trigger the decrement.

It also switches the import of the `sys` module to its new name `util`.
